### PR TITLE
Adds step value-passing.

### DIFF
--- a/spec/hopscotch/step_composers/default_spec.rb
+++ b/spec/hopscotch/step_composers/default_spec.rb
@@ -54,6 +54,22 @@ describe Hopscotch::StepComposers::Default do
       expect(r).to be_a(Proc)
       expect(r.call(111)).to eq([223, 110])
     end
+
+    it 'allows short pipelines of value-passing steps' do
+      effects = []
+      r = subject.compose_with_error_handling(
+        [
+          ->   { 123 },
+          -> n { n * 2 },
+          -> n { effects << n },
+        ],
+        -> { "ignores return value from previous step; returns a value that is ignored" },
+        -> { effects << "Sent Email" },
+        -> { "result" }
+      ).call
+      expect(r).to eq("result")
+      expect(effects).to eq([246, "Sent Email"])
+    end
   end
 
   describe '.call_each' do

--- a/spec/hopscotch/step_composers/default_spec.rb
+++ b/spec/hopscotch/step_composers/default_spec.rb
@@ -36,6 +36,24 @@ describe Hopscotch::StepComposers::Default do
       r = subject.compose_with_error_handling([[], [nil], nil])
       expect(r.call).to eq(true)
     end
+
+    it 'allows values to be passed between steps' do
+      r = subject.compose_with_error_handling(
+        ->            { 123 },                     # No args
+        -> (number)   { number * 2 },              # One arg
+        -> (*numbers) { numbers.map {|n| n + 1 } } # Many args
+      ).call
+      expect(r).to eq([247])
+    end
+
+    it 'uses currying for 1+ argument steps' do
+      r = subject.compose_with_error_handling(
+        -> (number) { number * 2     }, # One arg
+        -> (n, z)   { [n + 1, z - 1] }  # Two args; curried.
+      ).call(111)
+      expect(r).to be_a(Proc)
+      expect(r.call(111)).to eq([223, 110])
+    end
   end
 
   describe '.call_each' do


### PR DESCRIPTION
Uses currying for methods with 1+ arguments (eg. `->(x){}`, `->(*xs){}` or `->(x,y){}`), and special-cases no-arg methods for backwards-compatibility. An example from the specs:

``` ruby
subject.compose_with_error_handling(
  ->            { 111 },                     # No args
  -> (number)   { number * 2 },              # One arg
  -> (*numbers) { numbers.map {|n| n + 1 } } # Many args
).call
# => [223]; it's array because of that last step.
```

This is more of a proposal that came out a discussion in #ruby on the View Source slack group, resulting from some frustration with building a pipeline of dependent actions that can fail out part-way.

I don't have a particular horse in this race, so please don't be afraid to shoot this one down if you don't feel the changes are appropriate. :sweat_smile:
